### PR TITLE
Fix compatibility with Airflow < 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Two basic capabilities are supported:
 
 Note this package is in preview and it will not work with your Tecton installation unless enabled.
 
+## Changelog
+
+- 0.0.2 Removed type annotations that caused compatibility issues with Airflow versions below 2.4.
+
+- 0.0.1 Initial release
+
 # Installation and Configuration
 
 ## Installation

--- a/airflow_tecton/operators/tecton_job_operator.py
+++ b/airflow_tecton/operators/tecton_job_operator.py
@@ -20,7 +20,6 @@ from typing import Sequence
 from typing import Union
 
 from airflow.models import BaseOperator
-from airflow.utils.context import Context
 
 from airflow_tecton.hooks.tecton_hook import TectonHook
 
@@ -69,7 +68,7 @@ class TectonJobOperator(BaseOperator):
         self.conn_id = conn_id
         self.job_id = None
 
-    def execute(self, context: Context) -> Any:
+    def execute(self, context) -> Any:
         hook = TectonHook.create(self.conn_id)
         job = hook.find_materialization_job(
             workspace=self.workspace,

--- a/airflow_tecton/operators/tecton_trigger_operator.py
+++ b/airflow_tecton/operators/tecton_trigger_operator.py
@@ -19,7 +19,6 @@ from typing import Sequence
 from typing import Union
 
 from airflow.models import BaseOperator
-from airflow.utils.context import Context
 
 from airflow_tecton.hooks.tecton_hook import TectonHook
 
@@ -69,7 +68,7 @@ class TectonTriggerOperator(BaseOperator):
         self.end_time = end_time
         self.conn_id = conn_id
 
-    def execute(self, context: Context) -> List[str]:
+    def execute(self, context) -> List[str]:
         hook = TectonHook.create(self.conn_id)
 
         job = hook.find_materialization_job(

--- a/airflow_tecton/sensors/tecton_sensor.py
+++ b/airflow_tecton/sensors/tecton_sensor.py
@@ -15,8 +15,7 @@ import datetime
 import logging
 from typing import Sequence, Union, Optional
 
-from airflow.sensors.base import BaseSensorOperator, PokeReturnValue
-from airflow.utils.context import Context
+from airflow.sensors.base import BaseSensorOperator
 
 from airflow_tecton.hooks.tecton_hook import TectonHook
 
@@ -81,7 +80,7 @@ class TectonSensor(BaseSensorOperator):
         else:
             return self.ready_time
 
-    def poke(self, context: Context) -> Union[bool, PokeReturnValue]:
+    def poke(self, context) -> bool:
         hook = TectonHook(self.conn_id)
         if self.feature_view:
             readiness_resp = hook.get_latest_ready_time(

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="airflow-tecton",
-    version="0.0.1",
+    version="0.0.2",
     description="Provider for using Tecton with Airflow.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/operators/test_tecton_job_operator.py
+++ b/tests/operators/test_tecton_job_operator.py
@@ -15,8 +15,6 @@ import datetime
 import unittest
 from unittest.mock import patch, MagicMock, Mock
 
-from airflow.utils.context import Context
-
 from airflow_tecton.operators.tecton_job_operator import (
     TectonJobOperator,
 )
@@ -72,7 +70,7 @@ class TestTectonJobOperator(unittest.TestCase):
             start_time=datetime.datetime(2022, 7, 1),
             end_time=datetime.datetime(2022, 7, 2),
         )
-        operator.execute(Context())
+        operator.execute(None)
 
     @patch("time.sleep", return_value=None)
     @patch("airflow_tecton.operators.tecton_job_operator.TectonHook.create")
@@ -99,7 +97,7 @@ class TestTectonJobOperator(unittest.TestCase):
             start_time=datetime.datetime(2022, 7, 1),
             end_time=datetime.datetime(2022, 7, 2),
         )
-        operator.execute(Context())
+        operator.execute(None)
         assert mock_hook.cancel_materialization_job.call_count == 1
 
     @patch("time.sleep", return_value=None)
@@ -125,7 +123,7 @@ class TestTectonJobOperator(unittest.TestCase):
             end_time=datetime.datetime(2022, 7, 2),
         )
         with self.assertRaises(Exception) as e:
-            operator.execute(Context())
+            operator.execute(None)
         self.assertIn("Final job state", str(e.exception))
 
     @patch("time.sleep", return_value=None)
@@ -151,7 +149,7 @@ class TestTectonJobOperator(unittest.TestCase):
             end_time=datetime.datetime(2022, 7, 2),
         )
         with self.assertRaises(Exception) as e:
-            operator.execute(Context())
+            operator.execute(None)
         self.assertIn("Final job state", str(e.exception))
 
     @patch("airflow_tecton.operators.tecton_job_operator.TectonHook.create")

--- a/tests/operators/test_tecton_trigger_operator.py
+++ b/tests/operators/test_tecton_trigger_operator.py
@@ -16,8 +16,6 @@ import unittest
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
-from airflow.utils.context import Context
-
 from airflow_tecton.operators.tecton_trigger_operator import (
     TectonTriggerOperator,
 )
@@ -43,7 +41,7 @@ class TestTectonTriggerOperator(unittest.TestCase):
             start_time=datetime.datetime(2022, 7, 1),
             end_time=datetime.datetime(2022, 7, 2),
         )
-        self.assertEqual(["abc"], operator.execute(Context()))
+        self.assertEqual(["abc"], operator.execute(None))
 
     @patch("airflow_tecton.operators.tecton_trigger_operator.TectonHook.create")
     def test_execute_existing_job(self, mock_create):
@@ -61,4 +59,4 @@ class TestTectonTriggerOperator(unittest.TestCase):
             start_time=datetime.datetime(2022, 7, 1),
             end_time=datetime.datetime(2022, 7, 2),
         )
-        self.assertEqual(["cba"], operator.execute(Context()))
+        self.assertEqual(["cba"], operator.execute(None))

--- a/tests/sensors/test_tecton_sensor.py
+++ b/tests/sensors/test_tecton_sensor.py
@@ -15,8 +15,6 @@ import datetime
 import unittest
 from unittest.mock import patch, MagicMock, Mock
 
-from airflow.utils.context import Context
-
 from airflow_tecton.operators.tecton_trigger_operator import TectonTriggerOperator
 from airflow_tecton.sensors.tecton_sensor import TectonSensor
 
@@ -42,23 +40,23 @@ class TestTectonSensor(unittest.TestCase):
             ready_time=datetime.datetime(2022, 1, 31),
         )
         mock_hook.get_latest_ready_time.return_value = self._make_resp(None, None)
-        assert not sensor.poke(Context())
+        assert not sensor.poke(None)
         mock_hook.get_latest_ready_time.return_value = self._make_resp(
             None, datetime.datetime(2022, 1, 31)
         )
-        assert not sensor.poke(Context())
+        assert not sensor.poke(None)
         mock_hook.get_latest_ready_time.return_value = self._make_resp(
             datetime.datetime(2022, 1, 31), datetime.datetime(2022, 1, 31)
         )
-        assert sensor.poke(Context())
+        assert sensor.poke(None)
         mock_hook.get_latest_ready_time.return_value = self._make_resp(
             datetime.datetime(2022, 1, 30), datetime.datetime(2022, 1, 30)
         )
-        assert not sensor.poke(Context())
+        assert not sensor.poke(None)
         mock_hook.get_latest_ready_time.return_value = self._make_resp(
             datetime.datetime(2022, 1, 30), datetime.datetime(2022, 1, 31)
         )
-        assert not sensor.poke(Context())
+        assert not sensor.poke(None)
 
         sensor = TectonSensor(
             task_id="abc",
@@ -69,19 +67,19 @@ class TestTectonSensor(unittest.TestCase):
             ready_time=datetime.datetime(2022, 1, 31),
         )
         mock_hook.get_latest_ready_time.return_value = self._make_resp(None, None)
-        assert not sensor.poke(Context())
+        assert not sensor.poke(None)
         mock_hook.get_latest_ready_time.return_value = self._make_resp(
             datetime.datetime(2022, 1, 30), None
         )
-        assert not sensor.poke(Context())
+        assert not sensor.poke(None)
         mock_hook.get_latest_ready_time.return_value = self._make_resp(
             datetime.datetime(2022, 1, 31), None
         )
-        assert sensor.poke(Context())
+        assert sensor.poke(None)
         mock_hook.get_latest_ready_time.return_value = self._make_resp(
             datetime.datetime(2022, 1, 31), datetime.datetime(2022, 1, 30)
         )
-        assert sensor.poke(Context())
+        assert sensor.poke(None)
         sensor = TectonSensor(
             task_id="abc",
             workspace="prod",
@@ -91,17 +89,17 @@ class TestTectonSensor(unittest.TestCase):
             ready_time=datetime.datetime(2022, 1, 31),
         )
         mock_hook.get_latest_ready_time.return_value = self._make_resp(None, None)
-        assert not sensor.poke(Context())
+        assert not sensor.poke(None)
         mock_hook.get_latest_ready_time.return_value = self._make_resp(
             None,
             datetime.datetime(2022, 1, 30),
         )
-        assert not sensor.poke(Context())
+        assert not sensor.poke(None)
         mock_hook.get_latest_ready_time.return_value = self._make_resp(
             None,
             datetime.datetime(2022, 1, 31),
         )
-        assert sensor.poke(Context())
+        assert sensor.poke(None)
         mock_hook.get_latest_ready_time.return_value = self._make_resp(
             datetime.datetime(2022, 1, 30),
             datetime.datetime(2022, 1, 31),


### PR DESCRIPTION
These types don't exist in older versions of Airflow and we don't actually use the values so just erasing the typo annotations and using a dummy value in tests