### PR TITLE
Add Retries for Request Exceptions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,3 +59,6 @@ repos:
           - pytest
           - apache-airflow>=2.0
           - requests-mock
+          - pandas
+          - pyarrow
+          - fastparquet

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Two basic capabilities are supported:
 
 ## Changelog
 
-- 0.1.0 Added 2 new operators to support triggering Feature Table ingestion jobs 
+- 0.1.1 Improved Tecton connection stability by adding retries for requests
+
+- 0.1.0 Added 2 new operators to support triggering Feature Table ingestion jobs
 
 - 0.0.3 Added support for `allow_overwrite` setting in the operators
 
@@ -130,7 +132,7 @@ TectonTriggerOperator(
     online=True,
     offline=True,
 )
-``` 
+```
 
 ## Waiting For Materialization
 

--- a/airflow_tecton/hooks/tecton_hook.py
+++ b/airflow_tecton/hooks/tecton_hook.py
@@ -106,12 +106,15 @@ class TectonHook(BaseHook):
 
             try:
                 resp = conn.post(full_path, json.dumps(data))
-            except requests.exceptions.ConnectionError as re:
-                exc = re
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
+            ) as re:
                 if verbose:
                     logging.info(
-                        f"Recieved ConnectionError for attempt {i}/{num_retries}. Retrying..."
+                        f"Received an error for attempt {i + 1}/{num_retries}. Error: {re}"
                     )
+                    logging.info(f"Retrying request to {full_path}")
                 # Refresh session
                 self._create_conn()
                 continue


### PR DESCRIPTION
Added retries for making post requests to Tecton. If the error is a ConnectionError or Timeout, refresh the session and try again. If it's a different error, fail and do not retry. The max number of retries for a ConnectionError is 3. 

Also fixed the unit requirements and syntax changes due to pre-commit. 